### PR TITLE
删除FileDownloader中锁逻辑

### DIFF
--- a/helper/FileDownloader.cpp
+++ b/helper/FileDownloader.cpp
@@ -20,7 +20,6 @@ FileDownloader::FileDownloader() {}
 FileDownloader::~FileDownloader() {}
 
 bool FileDownloader::Download(const std::string& url, const FileDownloaderParam& param, const std::function<void(const Rcp_Response*, uint32_t)>& callback) {
-    std::lock_guard<std::mutex> lock(mutex);
     uint32_t errorCode;
     Rcp_Session* session = HMS_Rcp_CreateSession(nullptr, &errorCode);
     if (session == nullptr || errorCode != 0) {

--- a/helper/FileDownloader.h
+++ b/helper/FileDownloader.h
@@ -5,8 +5,6 @@
 #ifndef TARO_HARMONY_CPP_FILEDOWNLOADER_H
 #define TARO_HARMONY_CPP_FILEDOWNLOADER_H
 
-#include <mutex>
-
 #include "RemoteCommunicationKit/rcp.h"
 
 namespace TaroHelper {
@@ -19,9 +17,7 @@ class FileDownloader {
     static FileDownloader* instance;
     FileDownloader();
     ~FileDownloader();
-
-    std::mutex mutex;
-
+    
     public:
     FileDownloader(const FileDownloader&) = delete;
     FileDownloader& operator=(const FileDownloader&) = delete;


### PR DESCRIPTION
* 仔细观察了`FileDownloader::Download`的代码逻辑，相关变量都是局部变量，也没有读写`FileDownloader`自身数据。更无共享状态
* 同时也阅读了`RemoteCommunication`官方API文档也没有找到说明需要自行添加锁的逻辑。
* 综上所述，删除`FileDownloader`中的锁应该是安全的操作